### PR TITLE
remove php warnings

### DIFF
--- a/lib/Model/AddonPaymentsRefundPost.php
+++ b/lib/Model/AddonPaymentsRefundPost.php
@@ -294,6 +294,7 @@ class AddonPaymentsRefundPost implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -306,6 +307,7 @@ class AddonPaymentsRefundPost implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -319,6 +321,7 @@ class AddonPaymentsRefundPost implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -335,6 +338,7 @@ class AddonPaymentsRefundPost implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/lib/Model/AddonPaymentsRefundResponse.php
+++ b/lib/Model/AddonPaymentsRefundResponse.php
@@ -944,6 +944,7 @@ class AddonPaymentsRefundResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -956,6 +957,7 @@ class AddonPaymentsRefundResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -969,6 +971,7 @@ class AddonPaymentsRefundResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -985,6 +988,7 @@ class AddonPaymentsRefundResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/lib/Model/Customer.php
+++ b/lib/Model/Customer.php
@@ -360,6 +360,7 @@ class Customer implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -372,6 +373,7 @@ class Customer implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -385,6 +387,7 @@ class Customer implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -401,6 +404,7 @@ class Customer implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);


### PR DESCRIPTION
Eliminar php warnings:

```
Return type of MarketPay\Model\AddonPaymentsRefundResponse::offsetExists($offset) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in vendor/marketpay/sdk-php/lib/Model/AddonPaymentsRefundResponse.php on line 947
69
Return type of MarketPay\Model\AddonPaymentsRefundResponse::offsetUnset($offset) should either be compatible with ArrayAccess::offsetUnset(mixed $offset): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /vendor/marketpay/sdk-php/lib/Model/AddonPaymentsRefundResponse.php on line 988
69
Return type of MarketPay\Model\AddonPaymentsRefundResponse::offsetGet($offset) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /vendor/marketpay/sdk-php/lib/Model/AddonPaymentsRefundResponse.php on line 959
69
Return type of MarketPay\Model\AddonPaymentsRefundResponse::offsetSet($offset, $value) should either be compatible with ArrayAccess::offsetSet(mixed $offset, mixed $value): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /vendor/marketpay/sdk-php/lib/Model/AddonPaymentsRefundResponse.php on line 972
69
```